### PR TITLE
Fixing shell command to be used with parameters and add radare2@5.6.6

### DIFF
--- a/r2env/config/profiles.json
+++ b/r2env/config/profiles.json
@@ -139,6 +139,17 @@
         }
       },
       {
+        "id": "5.6.6",
+        "packages": {
+          "w32": "radare2-5.6.6-w32.zip",
+          "w64": "radare2-5.6.6-w64.zip",
+          "mac_x64": "radare2-5.6.6-amd64.pkg",
+          "mac_arm64": "radare2-5.6.6-m1.pkg",
+          "deb_i386": "radare2_5.6.6_i386.deb",
+          "deb_x64": "radare2_5.6.6_amd64.deb"
+        }
+      },
+      {
         "id": "git",
         "packages": {}
       }

--- a/r2env/core.py
+++ b/r2env/core.py
@@ -67,6 +67,8 @@ class R2Env:
         self.check_if_r2env_initialized()
         use_meson = kwargs["use_meson"] if "use_meson" in kwargs else False
         use_dist = kwargs["use_dist"] if "use_dist" in kwargs else False
+        if "@" not in package:
+            package = f"{package}@git"
         if not self._check_package_format(package):
             raise R2EnvException("[x] Invalid package format.")
         try:

--- a/r2env/package_manager.py
+++ b/r2env/package_manager.py
@@ -190,6 +190,8 @@ class PackageManager:
     @staticmethod
     def _build_using_acr(source_path, dst_path, logfile, r2env_path):
         """Only works in Unix systems"""
+        if host_distname() in "w64":
+            raise PackageManagerException(f"acr is not supported on Windows platform. Use meson instead.")
         exit_if_not_exists(['make'])
         print_console("[-] Building package using acr...")
         extra_flags = ""

--- a/r2env/package_manager.py
+++ b/r2env/package_manager.py
@@ -191,7 +191,7 @@ class PackageManager:
     def _build_using_acr(source_path, dst_path, logfile, r2env_path):
         """Only works in Unix systems"""
         if host_distname() in "w64":
-            raise PackageManagerException(f"acr is not supported on Windows platform. Use meson instead.")
+            raise PackageManagerException("acr is not supported on Windows platform. Use meson instead.")
         exit_if_not_exists(['make'])
         print_console("[-] Building package using acr...")
         extra_flags = ""

--- a/r2env/repl.py
+++ b/r2env/repl.py
@@ -92,6 +92,8 @@ class REPL:
             raise ActionException(f"Action {action} requires a package as an argument.")
         if action in self.actions_with_arguments:
             self.actions[action](args[0], use_meson=action_args.meson, use_dist=action_args.package)
+        elif action in "shell" and len(args) > 0:
+            self.actions[action](args[0])
         else:
             self.actions[action]()
 

--- a/r2env/test/test_core.py
+++ b/r2env/test/test_core.py
@@ -134,8 +134,8 @@ class TestCore(unittest.TestCase):
     @patch("r2env.core.R2Env.check_if_r2env_initialized")
     def test_install_successfully_failed(self, mock_initialized):
         mock_initialized.return_value = True
-        package = "radare2"
-        version = "5.3.0"
+        package = "radare2@"
+        version = ""
         with self.assertRaises(R2EnvException):
             R2Env().install(f"{package}{version}", use_dist=True)
 

--- a/r2env/test/test_package.py
+++ b/r2env/test/test_package.py
@@ -228,7 +228,7 @@ class TestPackageManager(unittest.TestCase):
     @patch("r2env.package_manager.wget")
     @patch("r2env.package_manager.PackageManager._get_pkgname")
     @patch("r2env.package_manager.PackageManager._get_disturl")
-    @patch("r2env.package_manager.hohost_distnamest_distname")
+    @patch("r2env.package_manager.host_distname")
     def test_install_from_dist_wget_is_called(self, mock_host_distname,
                                               mock__get_disturl,
                                               mock__get_pkgname,

--- a/r2env/test/test_package.py
+++ b/r2env/test/test_package.py
@@ -228,7 +228,7 @@ class TestPackageManager(unittest.TestCase):
     @patch("r2env.package_manager.wget")
     @patch("r2env.package_manager.PackageManager._get_pkgname")
     @patch("r2env.package_manager.PackageManager._get_disturl")
-    @patch("r2env.package_manager.host_distname")
+    @patch("r2env.package_manager.hohost_distnamest_distname")
     def test_install_from_dist_wget_is_called(self, mock_host_distname,
                                               mock__get_disturl,
                                               mock__get_pkgname,
@@ -395,3 +395,9 @@ class TestPackageManager(unittest.TestCase):
         mock_distname.return_value = "non_existent"
         with self.assertRaises(PackageManagerException):
             self.package_manager._uninstall_from_dist("radare2", "1.0.0")
+
+    @patch("r2env.package_manager.host_distname")
+    def test_acr_not_supported_on_windows(self, mock_distname):
+        mock_distname.return_value = "w64"
+        with self.assertRaises(PackageManagerException):
+            self.package_manager._build_using_acr("source", "dest", "logfile", "r2env")


### PR DESCRIPTION
- Add radare2@5.6.6 to profiles.json

- Fix shell command to be used using arguments.

-Raising an error using Windows with ACR (not supported)

- Use git as default version if not defined.  