### PR TITLE
 Fix None in string error from host_distname() on unsupported systems

### DIFF
--- a/r2env/package_manager.py
+++ b/r2env/package_manager.py
@@ -190,7 +190,7 @@ class PackageManager:
     @staticmethod
     def _build_using_acr(source_path, dst_path, logfile, r2env_path):
         """Only works in Unix systems"""
-        if host_distname() in "w64":
+        if host_distname() is not None and host_distname() in "w64":
             raise PackageManagerException("acr is not supported on Windows platform. Use meson instead.")
         exit_if_not_exists(['make'])
         print_console("[-] Building package using acr...")


### PR DESCRIPTION
On unsupported systems (e.g. SUSE), host_distname() returns None instead of a string, causing an error when _build_using_acr checks `if host_distname() in "w64"`

```
$ r2env add radare2@git
[*] Installing radare2@git package from source
[-] Cloning git version
[-] Cleaning Repo
Traceback (most recent call last):
  File "/home/users/user/.local/bin/r2env", line 10, in <module>
    sys.exit(main())
  File "/home/users/user/.local/lib/python3.6/site-packages/r2env/repl.py", line 114, in main
    REPL().run_action(action_args)
  File "/home/users/user/.local/lib/python3.6/site-packages/r2env/repl.py", line 94, in run_action
    self.actions[action](args[0], use_meson=action_args.meson, use_dist=action_args.package)
  File "/home/users/user/.local/lib/python3.6/site-packages/r2env/core.py", line 79, in install
    self._package_manager.install_package(profile, version, use_meson=use_meson, use_dist=use_dist)
  File "/home/users/user/.local/lib/python3.6/site-packages/r2env/package_manager.py", line 67, in install_package
    if self._build_from_source(profile, version, source_path, dst_dir, logfile, use_meson=use_meson):
  File "/home/users/user/.local/lib/python3.6/site-packages/r2env/package_manager.py", line 188, in _build_from_source
    return self._build_using_acr(source_path, dst_path, logfile, self._r2env_path)
  File "/home/users/user/.local/lib/python3.6/site-packages/r2env/package_manager.py", line 193, in _build_using_acr
    if host_distname() in "w64":
TypeError: 'in <string>' requires string as left operand, not NoneType
```