### PR TITLE
Attempt to pull new tags if fetching a tag fails

### DIFF
--- a/r2env/tools.py
+++ b/r2env/tools.py
@@ -81,7 +81,12 @@ def git_fetch(url, version, source_path):
                                       f"Verify the source path is not dirty. Error: {err}") \
             from err
     if version != "git":
-        repo.git.checkout(version)
+        try:
+            repo.git.checkout(version)
+        except git.GitCommandError:
+            # try again after pulling new tags from origin
+            repo.git.fetch("origin", "--tags")
+            repo.git.checkout(version)
     sms = repo.submodules
     for sm in sms:
         if not sm.module_exists():


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: #36
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

I edited the `git_fetch` function in `tools.py`, so that if `repo.git.checkout(version)` fails with a `git.GitCommandError`, it tries to fetch tags from `origin` and tries one more time, instead of immediately failing.

I am not super familiar with the `GitPython` module, but I did not see anything in the docs that would point to cleaner way to do things than pass the `--tags` flag.

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
